### PR TITLE
feat: update monthly relay limit UI

### DIFF
--- a/app/models/portal/queries.graphqls
+++ b/app/models/portal/queries.graphqls
@@ -50,6 +50,7 @@ query getUserAccount(
     name
     planType
     enterpriseLimit
+    monthlyUserLimit
     notifications {
       notificationType
       notificationSettings {

--- a/app/routes/account.$accountId.settings._index/view.tsx
+++ b/app/routes/account.$accountId.settings._index/view.tsx
@@ -12,6 +12,8 @@ import { Link } from "@remix-run/react"
 import { Identicon } from "~/components/Identicon"
 import { Account, RoleName } from "~/models/portal/sdk"
 import { AnalyticActions, AnalyticCategories, trackEvent } from "~/utils/analytics"
+import { commify } from "~/utils/formattingUtils"
+import { isUnlimitedPlan } from "~/utils/planUtils"
 
 type AccountSettingsViewProps = {
   account: Account
@@ -34,12 +36,29 @@ export const AccountSettingsView = ({ account, userRole }: AccountSettingsViewPr
         <Text pt={5}>A unique image representing your account. </Text>
       </Box>
       <Divider />
+      {isUnlimitedPlan(account.planType) && (
+        <>
+          <Stack align="flex-start" py={20}>
+            <Box>
+              <Text fw={600}>Monthly Relay Limit</Text>
+              <Text pt={5}>
+                {account.monthlyUserLimit === 0
+                  ? "You have no monthly relay limit. You may set a monthly relay limit in Account Settings."
+                  : `You have a monthly relay limit of ${commify(
+                      account.monthlyUserLimit,
+                    )} relays. Once you hit this limit, your account will stop working until the start of the next calendar month. You may increase this limit in Account Settings.`}
+              </Text>
+            </Box>
+          </Stack>
+          <Divider />
+        </>
+      )}
       {userRole !== RoleName.Member && (
         <>
           <Stack align="flex-start" py={20}>
             <Box>
-              <Text fw={600}>Account Name</Text>
-              <Text pt={5}>Modify your account name here. </Text>
+              <Text fw={600}>Account Settings</Text>
+              <Text pt={5}>Modify your account settings here. </Text>
             </Box>
             <Button
               color="gray"
@@ -53,7 +72,7 @@ export const AccountSettingsView = ({ account, userRole }: AccountSettingsViewPr
                 })
               }}
             >
-              Change name
+              Change settings
             </Button>
           </Stack>
           <Divider />


### PR DESCRIPTION
Adds a section to the Account Settings page to display and update the Monthly User Limit.

Feature added:

https://github.com/user-attachments/assets/5f387dea-bea3-49bc-a1f8-09699e2119bd

